### PR TITLE
Make examples link absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pytest
 The following code will give a brief overview of what this package can offer through 
 simple examples. 
 
-**A Complete list of all examples can be found <a href="docs/examples/">here</a>.**
+**A Complete list of all examples can be found <a href="https://github.com/sbg/sevenbridges-cwl/tree/master/docs/examples">here</a>.**
 
 ### <a name="example1">Run workflow on a SevenBridges platform</a>
 


### PR DESCRIPTION
If we have the link relative it breaks the Readme on PyPi. It's neat to have it as a relative link because then forks and branches can refer to their own changes, but it's important for the doc on PyPi to not break.